### PR TITLE
Add companion essay: After Hunger

### DIFF
--- a/docs/extra-4.html
+++ b/docs/extra-4.html
@@ -1,0 +1,131 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Hunger — After Hunger</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link href="https://fonts.googleapis.com/css2?family=Lexend:wght@300;400;500&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header>
+        <a href="index.html" class="home-link">Hunger</a>
+    </header>
+    <main data-type="extra" data-chapter="4">
+        <h1>After Hunger</h1>
+
+        <p>A novel can end in triumph or defeat, in marriage or death, in revelation or collapse. <em>Hunger</em> ends in none of these. It ends in departure. The narrator signs aboard a ship bound for England, a man with no experience claiming he can do anything. He is bluffing, of course, as he has bluffed his way through the entire book. But this time the bluff works. The captain says he can have a try. And then, in the novel's final paragraph, we get one of the most quietly devastating sentences in modern fiction:</p>
+
+        <blockquote><p>Out in the fjord I dragged myself up once, wet with fever and exhaustion, and gazed landwards, and bade farewell for the present to the town--to Christiania, where the windows gleamed so brightly in all the homes.</p></blockquote>
+
+        <p>That is the whole of the ending. There is no resolution, no lesson, no earned wisdom. There is a sick man on a ship looking back at a city full of lighted windows. The windows gleam in all the homes--all the homes that were never his, all the warmth he stood outside of for the length of the novel. It is an image of belonging seen from the position of permanent exclusion. The narrator does not overcome hunger. He flees it. He does not find his place in the world. He sails away from the only place he knows.</p>
+
+        <p>Compare this to the endings of the other great novels of dislocation. <em>The Great Gatsby</em> closes with boats borne back ceaselessly into the past--a gorgeous, oratorical sweep that turns one man's failure into the condition of American longing itself. The last paragraph of <em>Dubliners</em> finds Gabriel Conroy watching the snow fall "upon all the living and the dead," dissolving boundaries in a universal white silence. Even Beckett's <em>Molloy</em>, for all its radical indeterminacy, ends with the strange calm of a man who has stopped struggling: "I don't know. I don't know." Each of these endings achieves a kind of formal grandeur, a sense that the sentence itself has become large enough to contain more than one life.</p>
+
+        <p>Hamsun's ending does something different. It stays small. It stays with the particular. Those gleaming windows are not a metaphor for the human condition. They are windows, in a specific city, seen by a specific man who is running a fever. The power of the sentence lies in its plainness, and in what it does not say. The narrator does not tell us he is heartbroken. He does not tell us he is relieved. He bids farewell "for the present," as if he might come back, as if this were a temporary arrangement. It is the kind of lie people tell themselves when they are leaving forever.</p>
+
+        <h2>The Mind Betrays Itself</h2>
+
+        <p>Before the departure, though, comes the scene that might be the true climax of the novel--if a novel this formless can be said to have a climax. It is not a dramatic confrontation or a romantic catastrophe. It is a grocery bill.</p>
+
+        <p>The landlady asks the narrator to check her accounts. A simple column of figures: loaves at two and a half pence, a lamp chimney at three, soap, butter. He adds the numbers, finds the total correct, and she asks him to check each line individually. And then he hits it:</p>
+
+        <blockquote><p>Finally, I came to a dead stop at the following entry--"3. 5/16ths of a pound of cheese at 9d." My brain failed me completely; I stared stupidly down at the cheese, and got no farther.</p></blockquote>
+
+        <p>Five-sixteenths of a pound of cheese. Five ounces, the landlady explains--it is simply how Dutch cheese is sold. The narrator claims to understand, tries once more, and cannot do it. The arithmetic is elementary. A child could manage it. But hunger has colonized the last territory he believed secure. His mind, the one instrument he possesses, the faculty on which his identity as a writer depends, has buckled.</p>
+
+        <p>What makes the scene so devastating is the narrator's response. He does not weep or rage. He performs. He moves his lips, mutters numbers aloud, slides his finger down the column of figures as though steadily approaching a result. He is acting the part of a man who can think. And the landlady--this practical, pregnant, overworked woman--sees through him at once.</p>
+
+        <blockquote><p>She remarked that perhaps I was not accustomed to reckon in sixteenths; she mentioned also that she must only apply to some one who had a knowledge of sixteenths, to get the account properly revised.</p></blockquote>
+
+        <p>Her tact is more lacerating than cruelty would be. She speaks "not in any hurtful way to make me feel ashamed, but thoughtfully and seriously." She has simply reclassified him. He is no longer a lodger with prospects. He is a man who cannot add. And then, on her way out, the small devastating sentence: "Excuse me for taking up your time then."</p>
+
+        <p>The narrator's attempt to recover from this scene is one of the great passages of self-deception in literature. He reassures himself furiously: he noticed the landlady was pregnant, didn't he? He can hear a song from the kitchen and identify whether it is sung in tune. He can observe children quarreling in the street and follow every detail. Therefore his mind must be sound. The cheese was an anomaly. It was the cheese's fault, really--Dutch cheese with cloves and pepper, the smell alone enough to finish a man. "Set me, if you like, at five-sixteenths of good dairy butter," he tells himself. "That is another matter."</p>
+
+        <p>The comedy here is savage because the narrator's logic is not wrong, exactly. He can observe, he can notice, he can perceive with hallucinatory sharpness. What he can no longer do is the plodding, sequential, unglamorous work of thought. He can see the world but he cannot operate within it. Hunger has separated perception from function, the artist's eye from the citizen's competence. He is becoming a creature of pure consciousness with no practical capacity whatsoever--a condition that looks, from one angle, like madness, and from another, like the logical endpoint of the literary vocation pushed past all sustainable limits.</p>
+
+        <h2>The Boy Who Became Hamsun</h2>
+
+        <p>Knut Hamsun was born Knud Pedersen in 1859, in the village of Lom in the Gudbrandsdal valley, the fourth of seven children. His father was a tailor and smallholder. The family was poor. At nine, Hamsun was sent to live with an uncle who beat him and worked him relentlessly. His formal education was negligible. He left home as a teenager and worked as a peddler, a shoemaker's apprentice, a schoolteacher, a road laborer, and a sheriff's assistant before emigrating to America in 1882.</p>
+
+        <p>The American years are crucial. Hamsun crossed the Atlantic twice, spending roughly four years in the upper Midwest and the East Coast. He was a farmhand in North Dakota, a streetcar conductor in Chicago, a clerk, a lecturer, a journalist in Minneapolis. He was nobody. He was a Norwegian immigrant working menial jobs in a country that had no use for his ambitions, and the experience marked him permanently. When he returned to Scandinavia and settled in Copenhagen in 1888, he was twenty-nine years old, had published nothing of consequence, and was furious--at America, at the literary establishment, at the nineteenth-century realism of Ibsen and Zola that he considered exhausted and dishonest.</p>
+
+        <p><em>Hunger</em> was published in 1890, when Hamsun was thirty-one. It drew directly on his experience of near-starvation in Christiania in the mid-1880s, between his two American sojourns. The novel made him famous immediately. It was recognized, even by hostile reviewers, as something unprecedented--a work that had dispensed with plot, social context, and moral instruction in favor of the pure, terrifying intimacy of a single consciousness under siege. Over the next decade Hamsun produced <em>Mysteries</em>, <em>Pan</em>, and <em>Victoria</em>, consolidating a body of work that would reshape European fiction.</p>
+
+        <p>In 1920, he was awarded the Nobel Prize in Literature for <em>Growth of the Soil</em>, his pastoral epic about a pioneer farming the Norwegian wilderness. The prize honored a different Hamsun than the one who wrote <em>Hunger</em>--an older man who had turned from the city to the land, from psychology to agrarianism, from the restless modernist to the conservative sage. But the Nobel made him the most celebrated Scandinavian writer of his age, and it is the Nobel that makes what followed so impossible to look away from.</p>
+
+        <h2>The Catastrophe</h2>
+
+        <p>Hamsun's affinity for Germany was longstanding. He had been a Germanophile and Anglophobe since the First World War. He admired what he saw as the discipline and depth of German culture, and he despised the British Empire with an intensity that bordered on obsession. When the Nazis rose to power, Hamsun did not merely tolerate them. He embraced them. He saw in National Socialism a kinship with his own agrarian ideals, his contempt for urban modernity, his belief in the primacy of blood and soil.</p>
+
+        <p>When Germany invaded Norway on April 9, 1940, Hamsun supported the occupation. He wrote articles and gave interviews urging his countrymen to lay down their arms. He praised Vidkun Quisling's collaborationist government. He donated his Nobel medal to Joseph Goebbels as a gesture of admiration. On June 26, 1943, he traveled to Berchtesgaden and met Adolf Hitler in person. The meeting, by most accounts, went badly: Hamsun was eighty-three, nearly deaf, and used the audience to harangue Hitler about the brutality of the German administrator in Norway, Josef Terboven. Hitler was reportedly enraged. But Hamsun left the meeting unshaken in his convictions.</p>
+
+        <p>The most damning document came last. On May 7, 1945--one week after Hitler's death, the same day Germany surrendered--Hamsun published an obituary in the newspaper <em>Aftenposten</em>. He called Hitler "a warrior for humankind and a preacher of the gospel of justice for all nations." He called him "a reformer of the highest order." This was not a private delusion confided to a diary. It was a public eulogy for a man whose regime had murdered six million Jews, published in a Norwegian newspaper on the day the war in Europe ended. Hamsun was eighty-five years old. He knew exactly what he was doing.</p>
+
+        <p>After the liberation, Hamsun was arrested and held in a hospital. A psychiatric examination lasting 119 days concluded that he suffered from "permanently impaired mental faculties"--a diagnosis that enraged him and that many later scholars have questioned. The finding allowed the Norwegian authorities to avoid a full treason trial. Instead, a civil case was brought, and in 1948 Hamsun was ordered to pay 325,000 kroner in restitution. He was financially ruined. He spent his last years on his farm at Norholm, nearly deaf, increasingly isolated, writing one final book: <em>On Overgrown Paths</em>, published in 1949, a lucid and combative memoir that many readers took as evidence his mental faculties had never been impaired at all. He died on February 19, 1952, at the age of ninety-two.</p>
+
+        <h2>The Problem That Will Not Resolve</h2>
+
+        <p>So here is the case. The man who wrote the most empathetic portrait of poverty and psychological suffering in modern fiction--a book that enters the consciousness of a starving man with such fidelity that the reader can feel the walls of the stomach contracting--became a public advocate for a regime that starved millions to death in camps and ghettos and occupied cities. The author of the cheese scene, who understood better than anyone what it means to have your mind dismantled by deprivation, praised the architects of industrialized deprivation. This is not a matter of youthful indiscretion or political naivety. Hamsun supported the Nazis throughout the war, into his eighties, and never fully recanted.</p>
+
+        <p>The conversation about art and the moral failures of artists is by now well-worn. We have had it about Ezra Pound, who broadcast fascist propaganda from Rome. About Louis-Ferdinand Celine, whose antisemitic pamphlets remain so vile they were kept out of print in France for decades. About Martin Heidegger, whose philosophical language was entangled with Nazi ideology in ways scholars are still parsing. About Richard Wagner, whose operas Hitler adored and whose antisemitism was programmatic and vicious.</p>
+
+        <p>Hamsun's case is in some ways worse, because the gap between the art and the politics is so vertiginous. Pound's poetry is authoritarian in its aesthetics--its drive to master all of culture, to compel fragments into order. You can see a line, however crooked, from the <em>Cantos</em> to the radio broadcasts. Celine's novels are powered by the same raging contempt that fueled his pamphlets. But <em>Hunger</em>? <em>Hunger</em> is a book about powerlessness. About the dissolution of the self under pressure. About what it feels like to be nobody, to have nothing, to be at the mercy of a body you cannot feed and a city that does not care. There is nothing in the novel--not one sentence, not one image--that points toward fascism. And yet the man who wrote it became a fascist.</p>
+
+        <p>There are explanations, of course. Hamsun's Anglophobia, his agrarian romanticism, his belief that modern democracy was decadent, his lifelong hostility to the urban and the cosmopolitan. His increasing deafness, which isolated him from the world and may have made him more susceptible to ideology. His vanity, which was immense, and which the Nazis flattered expertly--Goebbels ordered a hundred thousand copies of his works printed after their meeting. But explanations are not resolutions. You cannot read the cheese scene and then read the Hitler obituary and make the two cohere. The incoherence is the point. It is the permanent scandal of Hamsun's life, and no amount of biographical context will dissolve it.</p>
+
+        <p>Isaac Bashevis Singer, a Nobel laureate himself and a Yiddish writer whose family was destroyed in the Holocaust, wrote that "the whole modern school of fiction in the twentieth century stems from Hamsun." He did not say this lightly. He did not say it in ignorance of Hamsun's politics. He said it because it was true, and because Singer understood that the history of literature is not a rewards ceremony for the virtuous.</p>
+
+        <h2>The Enormous Shadow</h2>
+
+        <p>The influence of <em>Hunger</em> on twentieth-century fiction is so pervasive that it has become invisible, like a river that has been diverted into so many channels that the original source is forgotten.</p>
+
+        <p>Franz Kafka read Hamsun early, and the mark is unmistakable. <em>The Metamorphosis</em>, published in 1915, takes the condition of Hamsun's narrator--a man trapped in a body that is failing him, increasingly alien to the world around him, dependent on the grudging charity of others--and literalizes it as insect transformation. Gregor Samsa wakes as a beetle; Hamsun's narrator wakes as something almost as monstrous, a thinking being who can no longer think. Kafka's 1922 story "A Hunger Artist" is an even more direct descendant: a man who makes a profession of starving, who discovers that his art consists precisely of deprivation, and who confesses at the end that he fasted only because he never found any food he liked. The hunger artist is Hamsun's narrator translated into parable--the writer whose medium is his own emptiness.</p>
+
+        <p>Samuel Beckett's tramps arrive from the same lineage. Vladimir and Estragon in <em>Waiting for Godot</em> are Hamsun's narrator stripped even of the city--placed on a bare road with a single tree, waiting for something that will not come. They bicker, they clown, they contemplate suicide, they eat a carrot. The structure of their days is the structure of <em>Hunger</em>: expectation, disappointment, the irrational persistence of hope, the comedy of desperation. Beckett takes Hamsun's single man and splits him into two, because even solitude, pushed far enough, becomes a kind of dialogue with oneself.</p>
+
+        <p>Henry Miller called Hamsun "the Dickens of my generation"--a remark that sounds paradoxical until you consider what Miller meant by it. Not the Dickens of social panorama and moral feeling, but the Dickens of sheer narrative energy, of prose so alive to physical experience that it makes the reader hungry, cold, footsore, euphoric. Miller's <em>Tropic of Cancer</em>, written in Paris in the early 1930s, is a book about a writer who has nothing and wants everything, who scrounges meals and sleeps in borrowed beds and talks incessantly about art and sex and the magnificent failure of his own ambitions. It is <em>Hunger</em> transplanted to Montparnasse, with the Protestantism removed and the libido turned up.</p>
+
+        <p>Charles Bukowski acknowledged the debt more bluntly. A character in his novel <em>Women</em> calls Hamsun the greatest writer who ever lived. Bukowski's <em>Factotum</em>, published in 1975, takes Hamsun's wandering narrator and sets him loose in wartime and postwar America, drifting from one miserable job to the next, writing in cheap rooms, drinking everything in sight. Where Hamsun's narrator starves with a kind of metaphysical grandeur, Bukowski's Henry Chinaski starves with a hangover. But the architecture is the same: the episodic, picaresque structure of failure, the comedy of a man who cannot quite be destroyed.</p>
+
+        <p>Paul Auster wrote an essay called "The Art of Hunger" in 1970, and the title became a kind of mission statement. In it, Auster argued that Hamsun "walks straight into the twentieth century" by translating the world of art into the world of the body. Auster's <em>Moon Palace</em>, published in 1989, follows a young man in 1960s New York through a process of self-starvation and dispossession that mirrors Hamsun's narrator almost scene for scene. The difference is that Auster's protagonist knows he is reenacting a literary tradition. He has read the books. He is starving in the library, surrounded by all the other stories of starvation. This self-consciousness is itself a measure of Hamsun's influence: by 1989, you could not write a novel about a starving writer without writing, in some sense, about <em>Hunger</em>.</p>
+
+        <h2>The Starving Writer in the Age of Precarity</h2>
+
+        <p>There is a temptation, with any classic, to declare it "more relevant than ever." Usually the claim is lazy. But with <em>Hunger</em> there is something to it that goes beyond the perennial appeal of a good novel.</p>
+
+        <p>Hamsun's narrator is a freelance writer. He has no employer, no safety net, no institutional affiliation. He produces work on speculation and submits it to editors who may or may not buy it. His income is irregular. His housing is precarious. He is one rejected article away from the street. He performs competence and well-being for the people around him while privately coming apart. He is, in the language of the twenty-first century, a gig worker. He is a content creator avant la lettre--producing words no one has commissioned, pitching stories no one has asked for, maintaining the fiction of professional viability while his shoes fall apart and his hair falls out.</p>
+
+        <p>The particular shame Hamsun captures--the shame of educated poverty, of downward mobility, of being intelligent enough to understand precisely how badly things are going--has not diminished. If anything, it has spread. The narrator's experience, once exotic enough to shock Scandinavian readers, is now recognizable to millions of people in the developed world who hold advanced degrees and cannot pay their rent. The journalist writing for publications that fold. The adjunct professor teaching four courses at three institutions for less than a living wage. The novelist with an MFA and a novel that does not sell. The distance between Hamsun's Christiania and the contemporary economy has not widened. It has collapsed.</p>
+
+        <p>What remains most modern about <em>Hunger</em> is not the social condition it describes but the psychology it renders. The narrator does not simply suffer. He suffers and watches himself suffer. He narrates his own degradation with a mixture of horror, fascination, and perverse amusement. He lies to others about his circumstances and then lies to himself about why he lied. He performs generosity he cannot afford. He rejects help he desperately needs. He oscillates between grandiosity and self-loathing so rapidly that the reader can barely keep up. This is not nineteenth-century realism. It is the texture of a mind under unbearable pressure, and it sounds remarkably like the interior monologue of anyone who has ever refreshed their bank balance at three in the morning, knowing what they would find.</p>
+
+        <h2>The Ship</h2>
+
+        <p>The novel's last movement is swift and strange. After the landlady throws him out, after the drama is torn to shreds, after the half-sovereign from Ylajali is thrown in the landlady's face in a gesture of suicidal pride, after the hallucinatory scene with the potatoes he insists are cabbages--swearing by the Father, Son, and Holy Ghost that they are cabbages--after all of this, the narrator simply walks to the harbor and asks if a ship needs a man.</p>
+
+        <p>He has no sailing experience. He is feverish, emaciated, half-blind without the glasses he furtively pockets to appear younger. But the captain of the <em>Copegoro</em>, a Russian barque bound for Leith and then Cadiz, takes him on. "Have a try at it," the captain says. "If it doesn't work, well, we can part in England."</p>
+
+        <p>There is no catharsis in this ending. No recognition scene, no reconciliation. The narrator does not learn anything. He does not grow. He escapes, and even the escape is provisional--the captain's conditional phrasing ("if it doesn't work") echoing all the conditional arrangements that have collapsed throughout the book. The ship is not salvation. It is another temporary arrangement, another bluff, another room that might be taken away.</p>
+
+        <p>And yet the ending is not hopeless. Or rather, it is not only hopeless. The narrator, who has lost everything--his lodging, his manuscript, his shoes, his ability to do arithmetic, the woman he thinks he loves--still has the capacity to act. He walks to the harbor. He asks a question. He boards a ship. These are small gestures, almost negligible, but they are not nothing. Hamsun understood that survival is not a grand narrative. It is a series of small, improbable decisions made by people who have every reason to stop making them.</p>
+
+        <p>The gleaming windows of Christiania, seen from the fjord, are the last image the novel gives us. They are beautiful and they are cruel. They represent everything the narrator wanted and could not have: warmth, shelter, belonging, a desk, a lamp, a room of his own where the spirit might move him and the allegory might be finished. The windows gleam "in all the homes"--that phrase, "all the homes," carrying the weight of everything the narrator's homelessness has meant. He is not looking back at a city. He is looking back at the idea of a life he was never granted.</p>
+
+        <p>Hamsun was thirty-one when he published this ending. He would live another sixty-two years, win the Nobel Prize, write a dozen more books, buy a grand estate, meet Adolf Hitler, eulogize him in print, be tried for treason, be declared mentally impaired, write a final book proving he was nothing of the kind, and die in his bed at ninety-two. The young man on the ship became one of the most celebrated and most reviled writers of the twentieth century. The novel he left behind--this small, ferocious, funny, agonizing book about a man who could not feed himself--became the headwater of modern fiction's deepest stream: the literature of the self at the end of its resources, the mind turning on itself in the dark.</p>
+
+        <p>The windows still gleam. The ship sails on. The hunger does not end.</p>
+
+    </main>
+    <nav class="chapter-nav">
+        <a href="extra-3.html">← Previous essay</a>
+        <a href="index.html">Home</a>
+        <span></span>
+    </nav>
+    <nav class="extra-nav">
+        <a href="part-4.html">← Back to Part IV</a>
+    </nav>
+    <script src="app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Companion essay for Part IV exploring the ending of *Hunger*, the cheese calculation scene as the novel's true climax, Hamsun's biography and Nazi catastrophe, the art-and-artist problem, the novel's enormous influence (Kafka, Beckett, Miller, Bukowski, Auster), and its relevance to contemporary precarity
- Closes-reads the final sentence ("where the windows gleamed so brightly in all the homes") alongside the endings of *The Great Gatsby*, *Dubliners*, and *Molloy*
- Treats Hamsun's politics honestly without moralizing, including the Hitler meeting, the Goebbels medal, and the obituary

Closes #4